### PR TITLE
agent/fix: prefix asset paths with BASE_URL

### DIFF
--- a/src/components/GameMap.tsx
+++ b/src/components/GameMap.tsx
@@ -16,8 +16,10 @@ interface SceneUnlock {
   unlock_xp: number;
 }
 
-// Path to the world map image asset
-const MAP_SRC = "/assets/images/map/world-map.png";
+// Path to the world map image asset. Prefix with BASE_URL so the
+// image loads correctly when the app is served from a subpath.
+const MAP_SRC =
+  import.meta.env.BASE_URL + "assets/images/map/world-map.png";
 
 /**
  * GameMap Component

--- a/src/components/Icon.tsx
+++ b/src/components/Icon.tsx
@@ -13,7 +13,7 @@ export interface IconProps {
 
 const Icon: FC<IconProps> = ({ name, size = 24, className }) => (
   <img
-    src={`/assets/icons/${name}.svg`}
+    src={`${import.meta.env.BASE_URL}assets/icons/${name}.svg`}
     alt={`${name} icon`}
     width={size}
     height={size}

--- a/src/components/Pokedex.tsx
+++ b/src/components/Pokedex.tsx
@@ -63,7 +63,7 @@ const Pokedex: FC = () => {
             >
               <CardMedia
                 component="img"
-                image={`/assets/images/pokemon/${String(pokemon.id).padStart(3, "0")}.png`}
+                image={`${import.meta.env.BASE_URL}assets/images/pokemon/${String(pokemon.id).padStart(3, "0")}.png`}
                 alt={pokemon.name.english}
                 loading="lazy"
                 sx={{ height: 140, objectFit: "contain", p: 2 }}

--- a/src/components/SceneView.tsx
+++ b/src/components/SceneView.tsx
@@ -39,8 +39,11 @@ const SceneView: FC = () => {
     );
   }
 
-  // Simple string concat—no hook needed
-  const backgroundPath = `/assets/images/backgrounds/${scene.background}`;
+  // Simple string concat—no hook needed. Prefix with BASE_URL so the image
+  // loads correctly when deployed under a subpath.
+  const backgroundPath =
+    import.meta.env.BASE_URL +
+    `assets/images/backgrounds/${scene.background}`;
 
   return (
     <Box sx={{ bgcolor: "grey.100", minHeight: "100vh", py: 4 }}>

--- a/src/components/SpellingChallenge.tsx
+++ b/src/components/SpellingChallenge.tsx
@@ -345,7 +345,7 @@ const SpellingChallenge: FC<SpellingChallengeProps> = ({
         </DialogTitle>
         <DialogContent sx={{ textAlign: "center" }}>
           <img
-            src={`/assets/images/pokemon/${String(lastCaught?.id).padStart(3, "0")}.png`}
+            src={`${import.meta.env.BASE_URL}assets/images/pokemon/${String(lastCaught?.id).padStart(3, "0")}.png`}
             alt={lastCaught?.name}
             style={{ width: "100%", maxWidth: 250, margin: "auto" }}
           />


### PR DESCRIPTION
## Summary
- prefix world map with BASE_URL
- prefix scene backgrounds with BASE_URL
- prefix icon src with BASE_URL
- prefix pokedex sprites with BASE_URL
- prefix capture sprite with BASE_URL

## Testing
- `npm run lint` *(fails: Missing script)*
- `npm run test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684c8f45615083329ccef71fd12c0ee9