### PR TITLE
agent/remove-tailwind: migrate docs and config

### DIFF
--- a/DEVELOPMENT_NOTES.md
+++ b/DEVELOPMENT_NOTES.md
@@ -14,8 +14,8 @@ This document complements inline `TODO:` comments. Each section lists guidance, 
 | **index.html**                              | _TODO:_ set `<title>` to **Spelling Adventure** and add favicon.                        |
 | **eslint.config.js**                        | Uses ESLint v9 flat-config. Strict TS + React + Prettier.                               |
 | **prettierrc.json**                         | Standard Prettier. Keep in sync with team preferences.                                  |
-| **vite.config.ts**                          | Uses `vite-tsconfig-paths` + `vite-plugin-svgr`. No Tailwind plugin.                    |
-| **tailwind.config.js / postcss.config.cjs** | **Removed** — project is 100 % MUI.                                                     |
+| **vite.config.ts**                          | Uses `vite-tsconfig-paths` + `vite-plugin-svgr`. MUI-only stack.                       |
+| **tailwind.config.js / postcss.config.cjs** | **Removed** — project now relies solely on MUI.                                         |
 | **tsconfig\*.json**                         | Strict + moduleResolution bundler. Maintain compatibility.                              |
 | **package.json**                            | Dev scripts: `dev`, `build`, `preview`, `lint`, `format`, `test`, `test:watch`.         |
 
@@ -56,7 +56,7 @@ This document complements inline `TODO:` comments. Each section lists guidance, 
 
 | File             | Notes                                                                                      |
 | ---------------- | ------------------------------------------------------------------------------------------ |
-| **lib/utils.ts** | `cn()` helper using `clsx` + `tailwind-merge` (kept for potential future utility merging). |
+| **lib/utils.ts** | `cn()` helper using `clsx`; includes `tailwind-merge` for optional utility deduplication. |
 
 ---
 

--- a/components.json
+++ b/components.json
@@ -3,13 +3,6 @@
   "style": "new-york",
   "rsc": false,
   "tsx": true,
-  "tailwind": {
-    "config": "tailwind.config.js",
-    "css": "src/index.css",
-    "baseColor": "slate",
-    "cssVariables": true,
-    "prefix": ""
-  },
   "aliases": {
     "components": "@/components",
     "utils": "@/lib/utils",

--- a/src/App.css
+++ b/src/App.css
@@ -1,8 +1,0 @@
-/*
-  Global styles for the game.
-
-  The project primarily uses Tailwind utility classes, however any additional
-  custom CSS rules that don't fit well into utility classes can live in this
-  file. Keeping it short helps ensure the design remains consistent across
-  components.
-*/

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,7 +1,7 @@
 // File: src/lib/utils.ts
 //
-// Utility to build className strings while safely merging Tailwind classes.
-// Uses `clsx` for conditional joins and `tailwind-merge` to resolve conflicts.
+// Utility to build className strings with optional conflict resolution.
+// Uses `clsx` for conditional joins and `tailwind-merge` to remove duplicates.
 //
 // Example:
 //   cn(
@@ -13,6 +13,6 @@
 import clsx, { type ClassValue } from "clsx";
 import { twMerge } from "tailwind-merge";
 
-/** Compose class names and merge Tailwind utility conflicts */
+/** Compose class names, removing duplicated utility classes */
 export const cn = (...classes: ClassValue[]): string =>
   twMerge(clsx(...classes));

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -10,7 +10,7 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 
-import "./index.css"; // Global Tailwind / MUI baseline styles
+import "./index.css"; // Global MUI baseline styles
 import App from "./App";
 
 const container = document.getElementById("root");


### PR DESCRIPTION
## Summary
- remove unused `src/App.css`
- strip Tailwind config from `components.json`
- revise bootstrap comment in `main.tsx`
- clarify `cn` helper docs
- update development notes to emphasize MUI-only stack

## Testing
- `npm run lint` *(fails: Missing script)*
- `npm run test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684c8f5af9d88332b2f9e32c971e89ca