### PR TITLE
Add catch-all route

### DIFF
--- a/DEVELOPMENT_NOTES.md
+++ b/DEVELOPMENT_NOTES.md
@@ -41,7 +41,7 @@ This file provides high-level guidance for developers working on the code base. 
 
 ### `App.tsx`
 - Defines routing only. Future screens should be added here.
-- TODO: Add NotFound route for unmatched URLs.
+- A NotFound route now handles unmatched URLs and redirects players back to the map.
 
 ### Components
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,16 @@ Game images, sounds and data files live under `public/assets`. When adding new a
 
 Keeping the asset list up to date helps others find files quickly and prevents missing resources at build time.
 
+## Navigation & Routes
+
+The game uses React Router for in-app navigation. The primary routes are:
+
+- `/` – world map where scenes can be selected
+- `/pokedex` – view the list of caught Pokémon
+- `/progress` – see player stats and earned badges
+- `/scene/:sceneId` – play the spelling challenge for a given scene
+- `*` – any unknown URL shows a friendly 404 page with a link back to the map
+
 ## Further Documentation
 
 - [`assets.md`](./assets.md) – complete asset reference

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,10 +15,10 @@
 //    lightweight. Expensive code should be split into the individual screens
 //    and lazily loaded if necessary.
 import { Routes, Route } from "react-router-dom";
+import NotFound from "./components/NotFound";
 //
 // Development Plan:
-// - Add a dedicated 404/NotFound component and route so unmatched URLs redirect
-//   players back to the map with a helpful message.
+// - Enhance the 404 page with custom artwork or tips once assets are ready.
 // - When more regions are introduced consider code-splitting heavy screens with
 //   React.lazy to keep the initial bundle small.
 // - Evaluate whether nested routing would simplify future sub-pages (e.g., a
@@ -63,14 +63,8 @@ function App() {
         for that scene.
       */}
       <Route path="/scene/:sceneId" element={<SceneView />} />
-      {
-        /*
-          TODO: Add a catch-all <Route> for unknown URLs. This ensures broken
-          links gracefully lead the player back to the main map. The 404 page
-          could reuse components from `shadcn/ui` to stay consistent with the
-          rest of the design.
-        */
-      }
+      {/* Catch-all route for unknown URLs */}
+      <Route path="*" element={<NotFound />} />
     </Routes>
   );
 }

--- a/src/components/NotFound.tsx
+++ b/src/components/NotFound.tsx
@@ -1,0 +1,32 @@
+// -----------------------------------------------------------------------------
+// NotFound Component (src/components/NotFound.tsx)
+// -----------------------------------------------------------------------------
+// Displays a friendly 404 page when the user navigates to an unknown route.
+// It provides a button to return to the main map so players don't get stuck.
+//
+// Development Plan:
+// - Add more thematic artwork once final assets are available.
+// - Include helpful links such as the Pokédex or progress page for quick access.
+// - Consider tracking 404 hits in analytics to discover broken links.
+
+import { useNavigate } from "react-router-dom";
+import { Box, Button, Typography } from "@mui/material";
+
+/**
+ * A simple fallback screen for unmatched routes.
+ */
+export default function NotFound() {
+  const navigate = useNavigate();
+
+  return (
+    <Box sx={{ p: 4, textAlign: "center" }}>
+      <Typography variant="h3" sx={{ mb: 2 }}>
+        Page Not Found
+      </Typography>
+      <Typography sx={{ mb: 4 }}>
+        The page you are looking for doesn’t exist.
+      </Typography>
+      <Button variant="contained" onClick={() => navigate("/")}>Return to Map</Button>
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary
- add NotFound component for unknown URLs
- wire NotFound page into router
- document available routes in README
- note new NotFound route in development notes

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6861aff222688332a5c83bc5f9ade5ec