### PR TITLE
Update favicon and docs

### DIFF
--- a/DEVELOPMENT_NOTES.md
+++ b/DEVELOPMENT_NOTES.md
@@ -16,7 +16,8 @@ This file provides high-level guidance for developers working on the code base. 
 
 ### `index.html`
 - Only hosts the React root element. Simple and fine as is.
-- TODO: Update `<title>` and icons to match the game name instead of "Vite + React + TS".
+- Title now reflects the game name and the favicon uses `pokeball_icon.svg` from
+  the `assets/icons` directory.
 
 ### `eslint.config.js`, `prettierrc.json`
 - Provide linting and formatting rules. Keep in sync with team style preferences.

--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ Game images, sounds and data files live under `public/assets`. When adding new a
 2. Use the recommended formats (PNG for images, SVG for icons, WAV/OGG for audio).
 3. Update `assets.md` to keep the inventory current.
 
+The site favicon now uses `pokeball_icon.svg` from the `public/assets/icons`
+directory to match the game's theme.
+
 Keeping the asset list up to date helps others find files quickly and prevents missing resources at build time.
 
 ## Navigation & Routes

--- a/assets.md
+++ b/assets.md
@@ -67,7 +67,8 @@ This document serves as the definitive, up-to-date reference for all assets and 
 - **Location:** `public/assets/icons/`
 - **Format:** SVG (preferred) or PNG, 128×128 px, transparent
 - **Filenames:**
-  `submit_icon.svg`, `clear_icon.svg`, `backspace_icon.svg`, `repeat_icon.svg`, `hint_icon.svg`, `xp_icon.svg`, `badge_icon.svg`, `menu_icon.svg`, `pokeball_icon.svg`, `crystal_icon.svg`
+`submit_icon.svg`, `clear_icon.svg`, `backspace_icon.svg`, `repeat_icon.svg`, `hint_icon.svg`, `xp_icon.svg`, `badge_icon.svg`, `menu_icon.svg`, `pokeball_icon.svg`, `crystal_icon.svg`
+  - The `pokeball_icon.svg` file also serves as the site's favicon.
 
 #### **Sound Effects**
 

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
       toggled on or off in different deployment environments.
   -->
   <meta charset="UTF-8" />
-  <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+  <link rel="icon" type="image/svg+xml" href="/assets/icons/pokeball_icon.svg" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Spelling Adventure</title>
 

--- a/indexHtml.test.ts
+++ b/indexHtml.test.ts
@@ -1,0 +1,17 @@
+// ---------------------------------------------------------------------------
+// index.html Regression Tests (indexHtml.test.ts)
+// ---------------------------------------------------------------------------
+// Ensures the root HTML file references the correct favicon so that
+// browsers display the themed icon rather than the Vite default.
+import { describe, it, expect } from "vitest";
+import fs from "fs";
+import { JSDOM } from "jsdom";
+
+describe("index.html", () => {
+  it("uses the Pokéball icon as the favicon", () => {
+    const html = fs.readFileSync("index.html", "utf8");
+    const dom = new JSDOM(html);
+    const link = dom.window.document.querySelector("link[rel='icon']");
+    expect(link?.getAttribute("href")).toBe("/assets/icons/pokeball_icon.svg");
+  });
+});


### PR DESCRIPTION
## Summary
- use pokeball icon for favicon
- document favicon in development notes, README, and assets list
- add regression test for index.html

## Testing
- `npm run build`
- `npx vitest run` *(fails: ModuleNotFoundError: No module named 'nltk')*


------
https://chatgpt.com/codex/tasks/task_e_6861bf861ee8833280863cec50e6950b