### PR TITLE
Implement scene background error fallback

### DIFF
--- a/docs/DEVELOPMENT_NOTES.md
+++ b/docs/DEVELOPMENT_NOTES.md
@@ -60,8 +60,8 @@ This file provides high-level guidance for developers working on the code base. 
 
 #### `SceneView.tsx`
 - Loads scene by ID from the URL and displays `SpellingChallenge`.
-- Uses inline styles for background image.
-- TODO: Add error handling for missing background assets.
+- Uses inline styles for background image and shows a fallback message if the
+  background image fails to load.
 
 #### `SpellingChallenge.tsx`
 - Core game logic. Uses Zustand store for XP, hints and Pokémon capture.

--- a/src/components/SceneView.test.tsx
+++ b/src/components/SceneView.test.tsx
@@ -1,0 +1,40 @@
+// ---------------------------------------------------------------------------
+// SceneView Error Handling Tests (src/components/SceneView.test.tsx)
+// ---------------------------------------------------------------------------
+// Ensures a friendly message is displayed when the background image cannot load.
+import { describe, it, expect, vi } from "vitest";
+import { render, fireEvent } from "@testing-library/react";
+import SceneView from "./SceneView";
+
+vi.mock("@/hooks/useBackgroundMusic", () => ({ default: () => {} }));
+
+vi.mock("@/data/scenes.json", () => ({
+  default: [
+    {
+      id: 1,
+      name: "Test Scene",
+      background: "missing.png",
+      word_start: 0,
+      word_end: 1,
+      music: "bg_forest.ogg",
+      unlock_xp: 0,
+    },
+  ],
+}));
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<any>("react-router-dom");
+  return {
+    ...actual,
+    useParams: () => ({ sceneId: "1" }),
+    useNavigate: () => vi.fn(),
+  };
+});
+
+describe("SceneView background errors", () => {
+  it("shows fallback text when the image fails to load", () => {
+    const { getByAltText, getByText } = render(<SceneView />);
+    fireEvent.error(getByAltText("Test Scene"));
+    expect(getByText(/background image failed to load/i)).toBeTruthy();
+  });
+});

--- a/src/components/SceneView.tsx
+++ b/src/components/SceneView.tsx
@@ -7,6 +7,7 @@
 // this code. The component uses React Router parameters to look up the scene by
 // ID and then renders the appropriate assets.
 import { useParams, useNavigate } from "react-router-dom";
+import { useState } from "react";
 // Scene definitions (background image, music track and word range) are stored in
 // a JSON file so that new scenes can be created without touching React code.
 import scenes from "@/data/scenes.json";
@@ -37,6 +38,8 @@ export default function SceneView() {
   // The hook will handle starting and stopping the music automatically.
   const backgroundMusic = scene ? `/assets/sounds/${scene.music}` : null;
   useBackgroundMusic(backgroundMusic);
+
+  const [bgError, setBgError] = useState(false);
 
   if (!scene) {
     return (
@@ -99,11 +102,29 @@ export default function SceneView() {
           </Box>
 
           {/* Scene Image */}
-          <img
-            src={backgroundPath}
-            alt={scene.name}
-            style={{ width: "100%", display: "block" }}
-          />
+          {bgError ? (
+            <Box
+              sx={{
+                width: "100%",
+                height: 300,
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                bgcolor: "grey.200",
+              }}
+            >
+              <Typography color="text.secondary">
+                Background image failed to load
+              </Typography>
+            </Box>
+          ) : (
+            <img
+              src={backgroundPath}
+              alt={scene.name}
+              onError={() => setBgError(true)}
+              style={{ width: "100%", display: "block" }}
+            />
+          )}
         </Paper>
 
         {/*


### PR DESCRIPTION
## Summary
- display fallback message if a scene background image fails to load
- document the new behaviour in development notes
- add unit test for background image error handling

## Testing
- `npx vitest run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6861d22493a083329682edebd07271d1