### PR TITLE
Add service unit tests

### DIFF
--- a/src/services/audioService.test.ts
+++ b/src/services/audioService.test.ts
@@ -1,0 +1,62 @@
+// ---------------------------------------------------------------------------
+// audioService Unit Tests (src/services/audioService.test.ts)
+// ---------------------------------------------------------------------------
+// Verifies background music helper functions control a shared audio element.
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+class MockAudio {
+  src = "";
+  volume = 1;
+  loop = false;
+  paused = true;
+  play = vi.fn(() => {
+    this.paused = false;
+    return Promise.resolve();
+  });
+  pause = vi.fn(() => {
+    this.paused = true;
+  });
+}
+
+let mockAudio: MockAudio;
+
+beforeEach(() => {
+  mockAudio = new MockAudio();
+  (global as any).Audio = vi.fn(() => mockAudio);
+  vi.resetModules();
+});
+
+describe("audioService", () => {
+  it("plays a new music track", async () => {
+    const mod = await import("./audioService");
+    mod.playBackgroundMusic("song.mp3");
+    expect(mockAudio.src).toBe("song.mp3");
+    expect(mockAudio.play).toHaveBeenCalled();
+  });
+
+  it("does not replay the same track", async () => {
+    const mod = await import("./audioService");
+    mod.playBackgroundMusic("song.mp3");
+    mockAudio.play.mockClear();
+    mod.playBackgroundMusic("song.mp3");
+    expect(mockAudio.play).not.toHaveBeenCalled();
+  });
+
+  it("pauses and resumes playback", async () => {
+    const mod = await import("./audioService");
+    mod.playBackgroundMusic("song.mp3");
+    mod.pauseBackgroundMusic();
+    expect(mockAudio.pause).toHaveBeenCalled();
+    mockAudio.pause.mockClear();
+    mockAudio.play.mockClear();
+    mod.resumeBackgroundMusic();
+    expect(mockAudio.play).toHaveBeenCalled();
+  });
+
+  it("stops playback", async () => {
+    const mod = await import("./audioService");
+    mod.playBackgroundMusic("song.mp3");
+    mod.stopBackgroundMusic();
+    expect(mockAudio.pause).toHaveBeenCalled();
+  });
+});

--- a/src/services/gameState.actions.test.ts
+++ b/src/services/gameState.actions.test.ts
@@ -1,0 +1,32 @@
+// ---------------------------------------------------------------------------
+// gameState Action Tests (src/services/gameState.actions.test.ts)
+// ---------------------------------------------------------------------------
+// Additional unit tests covering XP gain and word mastery rewards.
+import { describe, it, expect, beforeEach } from "vitest";
+import { useGameStore } from "./gameState";
+
+describe("gameState actions", () => {
+  beforeEach(() => {
+    useGameStore.getState().resetProgress();
+  });
+
+  it("levels up when enough XP is gained", () => {
+    useGameStore.getState().addXp(120);
+    const state = useGameStore.getState();
+    expect(state.level).toBe(2);
+    expect(state.xp).toBe(120);
+    expect(state.xpToNextLevel).toBe(200);
+  });
+
+  it("increments words mastered and awards hint", () => {
+    const store = useGameStore.getState();
+    store.spendHint();
+    for (let i = 0; i < 5; i++) {
+      store.incrementWordsMastered(i);
+    }
+    const updated = useGameStore.getState();
+    expect(updated.wordsMastered).toBe(5);
+    expect(updated.masteredWordIndices.length).toBe(5);
+    expect(updated.hintCharges).toBe(2);
+  });
+});

--- a/src/services/ttsService.test.ts
+++ b/src/services/ttsService.test.ts
@@ -1,0 +1,48 @@
+// ---------------------------------------------------------------------------
+// ttsService Unit Tests (src/services/ttsService.test.ts)
+// ---------------------------------------------------------------------------
+// Ensures the text-to-speech wrapper selects a voice and formats SSML correctly.
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+let speakFunc: (text: string, phonetic?: string) => void;
+let lastUtterance: any;
+let speakSpy: any;
+
+class MockUtterance {
+  text = "";
+  voice: any = null;
+  lang = "";
+  rate = 1;
+  pitch = 1;
+  addEventListener = vi.fn();
+}
+
+beforeEach(async () => {
+  lastUtterance = new MockUtterance();
+  speakSpy = vi.fn();
+  (global as any).SpeechSynthesisUtterance = vi.fn(() => lastUtterance);
+  (global as any).speechSynthesis = {
+    cancel: vi.fn(),
+    speak: speakSpy,
+    getVoices: vi.fn(() => [
+      { name: "Google US English", lang: "en-US" },
+    ]),
+  };
+  const mod = await import("./ttsService");
+  speakFunc = mod.speak;
+});
+
+describe("speak", () => {
+  it("passes plain text to speechSynthesis", () => {
+    speakFunc("hello");
+    expect(speakSpy).toHaveBeenCalled();
+    expect(lastUtterance.text).toBe("hello");
+  });
+
+  it("converts ARPAbet to IPA when phonetic is provided", () => {
+    speakFunc("hello", "HH-AH-L-OW");
+    expect(lastUtterance.text).toBe(
+      "<speak><phoneme alphabet=\"ipa\" ph=\"hʌloʊ\">hello</phoneme></speak>"
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for audioService background music helpers
- test ttsService voice/SSML logic
- extend gameState store coverage

## Testing
- `npx vitest run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6861effc72788332be9b36c0ad86372a